### PR TITLE
App.tsx: attempt a save before an export

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,6 +24,7 @@ function App() {
         {pdfInstance && (
           <button
             onClick={async () => {
+              await pdfInstance.save()
               const buffer = await pdfInstance.exportPDF({
                 flatten: true,
                 incremental: false,


### PR DESCRIPTION
Saving before exporting does not export the document with its bookmarks, at least no bookmarks are visible in macos preview app. I noticed that nothing is under the Highlights and Notes either... 